### PR TITLE
Added automation spec parametrization utils

### DIFF
--- a/Plugins/WeekendUtils/CREDITS.md
+++ b/Plugins/WeekendUtils/CREDITS.md
@@ -1,4 +1,5 @@
 This library was initially developed by Benjamin Barz with help by the following contributors listed in alphabetical order:
 
     Aesir Interactive GmbH
+    Gregor Sönnichsen
     Nine Worlds Studios GmbH

--- a/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecDescriptionUtils.h
+++ b/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecDescriptionUtils.h
@@ -22,18 +22,21 @@ namespace WeekendUtils
 		 */
 		FORCEINLINE FString ToString(const float Float)
 		{
-			return FString::FromInt(FMath::TruncToInt(Float)) + ","
+			return (FMath::Sign(Float) < 0.0f ? "-" : "")
+				+ FString::FromInt(FMath::Abs(FMath::TruncToInt(Float))) + ","
 				+ FString::FromInt(StaticCast<int>(FMath::Frac(Float) * 100));
 		}
 		
 		/**
 		 * Alternative implementation of ToString for double which doesn't introduce weird sub-categories
 		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
-		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(2.3f)), [this](){ ... });
+		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(2.3)), [this](){ ... });
 		 */
 		FORCEINLINE FString ToString(const double Double)
 		{
-			return FString::FromInt(StaticCast<int>(Double)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Double) * 100));
+			return (FMath::Sign(Double) < 0.0 ? "-" : "")
+				+ FString::FromInt(FMath::Abs(FMath::TruncToInt(Double))) + ","
+				+ FString::FromInt(StaticCast<int>(FMath::Frac(Double) * 100));
 		}
 		
 		/**

--- a/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecDescriptionUtils.h
+++ b/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecDescriptionUtils.h
@@ -22,9 +22,8 @@ namespace WeekendUtils
 		 */
 		FORCEINLINE FString ToString(const float Float)
 		{
-			return (FMath::Sign(Float) == 1.f ? "" : "-")
-				+ FString::FromInt(StaticCast<int>(FMath::Abs(Float))) + ","
-				+ FString::FromInt(StaticCast<int>(FMath::Frac(Float) * 10));
+			return FString::FromInt(FMath::TruncToInt(Float)) + ","
+				+ FString::FromInt(StaticCast<int>(FMath::Frac(Float) * 100));
 		}
 		
 		/**
@@ -34,7 +33,7 @@ namespace WeekendUtils
 		 */
 		FORCEINLINE FString ToString(const double Double)
 		{
-			return FString::FromInt(StaticCast<int>(Double)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Double) * 10));
+			return FString::FromInt(StaticCast<int>(Double)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Double) * 100));
 		}
 		
 		/**

--- a/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecDescriptionUtils.h
+++ b/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecDescriptionUtils.h
@@ -16,15 +16,35 @@ namespace WeekendUtils
 	namespace SpecStringUtils
 	{
 		/**
+		 * Alternative implementation of ToString for float which doesn't introduce weird sub-categories
+		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
+		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(2.3f)), [this](){ ... });
+		 */
+		FORCEINLINE FString ToString(const float Float)
+		{
+			return (FMath::Sign(Float) == 1.f ? "" : "-")
+				+ FString::FromInt(StaticCast<int>(FMath::Abs(Float))) + ","
+				+ FString::FromInt(StaticCast<int>(FMath::Frac(Float) * 10));
+		}
+		
+		/**
+		 * Alternative implementation of ToString for double which doesn't introduce weird sub-categories
+		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
+		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(2.3f)), [this](){ ... });
+		 */
+		FORCEINLINE FString ToString(const double Double)
+		{
+			return FString::FromInt(StaticCast<int>(Double)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Double) * 10));
+		}
+		
+		/**
 		 * Alternative implementation of ToString for FVector2 which doesn't introduce weird sub-categories
 		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
 		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(Vector)), [this](){ ... });
 		 */
 		FORCEINLINE FString ToString(const FVector2f& Vector)
 		{
-			return { "(" +
-				FString::FromInt(StaticCast<int>(Vector.X)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.X) * 10)) + " | " +
-				FString::FromInt(StaticCast<int>(Vector.Y)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Y) * 10)) + ")" };
+			return "(" + ToString(Vector.X) + " | " + ToString(Vector.Y) + ")";
 		}
 		
 		/**
@@ -34,9 +54,7 @@ namespace WeekendUtils
 		 */
 		FORCEINLINE FString ToString(const FVector2d& Vector)
 		{
-			return { "(" +
-				FString::FromInt(StaticCast<int>(Vector.X)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.X) * 10)) + " | " +
-				FString::FromInt(StaticCast<int>(Vector.Y)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Y) * 10)) + ")" };
+			return "(" + ToString(Vector.X) + " | " + ToString(Vector.Y) + ")";
 		}
 		
 		/**
@@ -46,10 +64,7 @@ namespace WeekendUtils
 		 */
 		FORCEINLINE FString ToString(const FVector& Vector)
 		{
-			return { "(" +
-				FString::FromInt(StaticCast<int>(Vector.X)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.X) * 10)) + " | " +
-				FString::FromInt(StaticCast<int>(Vector.Y)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Y) * 10)) + " | " +
-				FString::FromInt(StaticCast<int>(Vector.Z)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Z) * 10)) + ")" };
+			return "(" + ToString(Vector.X) + " | " + ToString(Vector.Y) + " | " + ToString(Vector.Z) + ")";
 		}
 	}
 }

--- a/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecMacros.h
+++ b/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecMacros.h
@@ -19,7 +19,7 @@
 // AutomationTest.h and are not supposed to be a complete replacement,
 // but rather an augmentation of the latter.
 //
-// All of the macros in this file must contain the initials NW to avoid
+// All of the macros in this file must contain the initials WE to avoid
 // name clashes and make them easily distinguishable!
 //////////////////////////////////////////////////////////////////////////
 

--- a/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecParametrizationMacros.h
+++ b/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecParametrizationMacros.h
@@ -1,0 +1,238 @@
+﻿///////////////////////////////////////////////////////////////////////////////////////
+/// Copyright (C) by Benjamin Barz and contributors. See file: CREDITS.md
+///
+/// This file is part of the WeekendUtils UE5 Plugin.
+///
+/// Distributed under the MIT License. See file: LICENSE.md
+///
+///////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#if WITH_AUTOMATION_WORKER
+
+//////////////////////////////////////////////////////////////////////////
+// This header file contains utility macros that should aid in the creation
+// of parametrized automated tests.
+// Parametrization means that a single Describe or It call is reused and executed
+// for a set of parameter payloads.
+//
+// All of the macros in this file must contain the initials WE to avoid
+// name clashes and make them easily distinguishable!
+//
+// Example of using the WE_SPEC_CASE* macros to parametrize an automation spec test:
+// -------------------------
+//	WE_SPEC_CASES_SIGNATURE_2(FVector, bool)
+//		WE_SPEC_CASE_2(FVector(0.f, 0.f), false)
+//		WE_SPEC_CASE_2(FVector(0.f, 1.f), true)
+//	WE_SPEC_CASES_CODE_BEGIN_2(Direction, bExpectIsZero)
+//	Describe("With direction", [Case]()
+//	{
+//		TestEquals(Case.Direction.IsNearlyZero(), Case.bExpectIsZero);
+//	});
+//	WE_SPEC_CASES_CODE_END()
+//////////////////////////////////////////////////////////////////////////
+
+////////////////////////
+// Case Signature Macros
+
+/**
+ * Use this macro in an automation spec to declare the type signature of case parameters.
+ * The WE_SPEC_CASE_* macro usages following this will expect their parameters to have
+ * the same types in the same order.
+ * For a full example in context of an automation spec see the beginning of this header.
+ */
+#define WE_SPEC_CASES_SIGNATURE_1(Param1Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type;
+
+#define WE_SPEC_CASES_SIGNATURE_2(Param1Type, Param2Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type;
+
+#define WE_SPEC_CASES_SIGNATURE_3(Param1Type, Param2Type, Param3Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type;
+
+#define WE_SPEC_CASES_SIGNATURE_4(Param1Type, Param2Type, Param3Type, Param4Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; Param4Type Param4; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type; \
+	typedef Param4Type WE_Param4Type;
+
+#define WE_SPEC_CASES_SIGNATURE_5(Param1Type, Param2Type, Param3Type, Param4Type, Param5Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; Param4Type Param4; Param5Type Param5; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type; \
+	typedef Param4Type WE_Param4Type; \
+	typedef Param5Type WE_Param5Type;
+
+#define WE_SPEC_CASES_SIGNATURE_6(Param1Type, Param2Type, Param3Type, Param4Type, Param5Type, Param6Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; Param4Type Param4; Param5Type Param5; Param6Type Param6; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type; \
+	typedef Param4Type WE_Param4Type; \
+	typedef Param5Type WE_Param5Type; \
+	typedef Param6Type WE_Param6Type;
+
+#define WE_SPEC_CASES_SIGNATURE_7(Param1Type, Param2Type, Param3Type, Param4Type, Param5Type, Param6Type, Param7Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; Param4Type Param4; Param5Type Param5; Param6Type Param6; Param7Type Param7; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type; \
+	typedef Param4Type WE_Param4Type; \
+	typedef Param5Type WE_Param5Type; \
+	typedef Param6Type WE_Param6Type; \
+	typedef Param7Type WE_Param7Type;
+
+#define WE_SPEC_CASES_SIGNATURE_8(Param1Type, Param2Type, Param3Type, Param4Type, Param5Type, Param6Type, Param7Type, Param8Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; Param4Type Param4; Param5Type Param5; Param6Type Param6; Param7Type Param7; Param8Type Param8; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type; \
+	typedef Param4Type WE_Param4Type; \
+	typedef Param5Type WE_Param5Type; \
+	typedef Param6Type WE_Param6Type; \
+	typedef Param7Type WE_Param7Type; \
+	typedef Param8Type WE_Param8Type;
+
+#define WE_SPEC_CASES_SIGNATURE_9(Param1Type, Param2Type, Param3Type, Param4Type, Param5Type, Param6Type, Param7Type, Param8Type, Param9Type) \
+{ \
+	struct FTestCaseInternal { Param1Type Param1; Param2Type Param2; Param3Type Param3; Param4Type Param4; Param5Type Param5; Param6Type Param6; Param7Type Param7; Param8Type Param8; Param9Type Param9; }; \
+	TArray<FTestCaseInternal> WE_Spec_Cases = {}; \
+	typedef Param1Type WE_Param1Type; \
+	typedef Param2Type WE_Param2Type; \
+	typedef Param3Type WE_Param3Type; \
+	typedef Param4Type WE_Param4Type; \
+	typedef Param5Type WE_Param5Type; \
+	typedef Param6Type WE_Param6Type; \
+	typedef Param7Type WE_Param7Type; \
+	typedef Param8Type WE_Param8Type; \
+	typedef Param9Type WE_Param9Type;
+
+////////////////////////
+// Case Macros
+
+/**
+ * Use this macro in an automation spec to describe a single case parameter set.
+ * The values must follow the type signature declared with WE_SPEC_CASES_SIGNATURE_.
+ * For a full example in context of an automation spec see the beginning of this header.
+ */
+#define WE_SPEC_CASE_1(Param1) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1 });
+#define WE_SPEC_CASE_2(Param1, Param2) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2 });
+#define WE_SPEC_CASE_3(Param1, Param2, Param3) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3 });
+#define WE_SPEC_CASE_4(Param1, Param2, Param3, Param4) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3, Param4 });
+#define WE_SPEC_CASE_5(Param1, Param2, Param3, Param4, Param5) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3, Param4, Param5 });
+#define WE_SPEC_CASE_6(Param1, Param2, Param3, Param4, Param5, Param6) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3, Param4, Param5, Param6 });
+#define WE_SPEC_CASE_7(Param1, Param2, Param3, Param4, Param5, Param6, Param7) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3, Param4, Param5, Param6, Param7 });
+#define WE_SPEC_CASE_8(Param1, Param2, Param3, Param4, Param5, Param6, Param7, Param8) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3, Param4, Param5, Param6, Param7, Param8 });
+#define WE_SPEC_CASE_9(Param1, Param2, Param3, Param4, Param5, Param6, Param7, Param8, Param9) \
+	WE_Spec_Cases.Add(FTestCaseInternal{ Param1, Param2, Param3, Param4, Param5, Param6, Param7, Param8, Param9 });
+
+////////////////////////
+// Parametrized Code Begin Macros
+
+/**
+ * Use this macro in an automation spec to begin a parametrized testing code and name
+ * the case parameters described before.
+ * After this call, you'll have a variable `Case : FTestCase` available, on which you
+ * can access the case values using the names you declared with this macro.
+ * For a full example in context of an automation spec see the beginning of this header.
+ */
+#define WE_SPEC_CASES_CODE_BEGIN_1(Param1Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1 };
+		
+#define WE_SPEC_CASES_CODE_BEGIN_2(Param1Name, Param2Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2 };
+		
+#define WE_SPEC_CASES_CODE_BEGIN_3(Param1Name, Param2Name, Param3Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3 };
+		
+#define WE_SPEC_CASES_CODE_BEGIN_4(Param1Name, Param2Name, Param3Name, Param4Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name;; WE_Param4Type Param4Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3, WE_TestCaseInternal.Param4 };
+		
+#define WE_SPEC_CASES_CODE_BEGIN_5(Param1Name, Param2Name, Param3Name, Param4Name, Param5Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name; WE_Param4Type Param4Name; WE_Param5Type Param5Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3, WE_TestCaseInternal.Param4, WE_TestCaseInternal.Param5 };
+		
+#define WE_SPEC_CASES_CODE_BEGIN_6(Param1Name, Param2Name, Param3Name, Param4Name, Param5Name, Param6Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name; WE_Param4Type Param4Name; WE_Param5Type Param5Name; WE_Param6Type Param6Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3, WE_TestCaseInternal.Param4, WE_TestCaseInternal.Param5, WE_TestCaseInternal.Param6 };
+		
+#define WE_SPEC_CASES_CODE_BEGIN_7(Param1Name, Param2Name, Param3Name, Param4Name, Param5Name, Param6Name, Param7Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name; WE_Param4Type Param4Name; WE_Param5Type Param5Name; WE_Param6Type Param6Name; WE_Param7Type Param7Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3, WE_TestCaseInternal.Param4, WE_TestCaseInternal.Param5, WE_TestCaseInternal.Param6, WE_TestCaseInternal.Param7 };
+
+#define WE_SPEC_CASES_CODE_BEGIN_8(Param1Name, Param2Name, Param3Name, Param4Name, Param5Name, Param6Name, Param7Name, Param8Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name; WE_Param4Type Param4Name; WE_Param5Type Param5Name; WE_Param6Type Param6Name; WE_Param7Type Param7Name; WE_Param8Type Param8Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3, WE_TestCaseInternal.Param4, WE_TestCaseInternal.Param5, WE_TestCaseInternal.Param6, WE_TestCaseInternal.Param7, WE_TestCaseInternal.Param8 };
+
+#define WE_SPEC_CASES_CODE_BEGIN_9(Param1Name, Param2Name, Param3Name, Param4Name, Param5Name, Param6Name, Param7Name, Param8Name, Param9Name) \
+	for (const FTestCaseInternal& WE_TestCaseInternal : WE_Spec_Cases) \
+	{ \
+		struct FTestCase { WE_Param1Type Param1Name; WE_Param2Type Param2Name; WE_Param3Type Param3Name; WE_Param4Type Param4Name; WE_Param5Type Param5Name; WE_Param6Type Param6Name; WE_Param7Type Param7Name; WE_Param8Type Param8Name; WE_Param9Type Param9Name; }; \
+		const FTestCase Case { WE_TestCaseInternal.Param1, WE_TestCaseInternal.Param2, WE_TestCaseInternal.Param3, WE_TestCaseInternal.Param4, WE_TestCaseInternal.Param5, WE_TestCaseInternal.Param6, WE_TestCaseInternal.Param7, WE_TestCaseInternal.Param8, WE_TestCaseInternal.Param9 };
+
+////////////////////////
+// Parametrized Code End Macro
+
+/**
+ * Use this macro in an automation spec to end a parametrized testing code.
+ * Does nothing special besides closing code scopes.
+ * For a full example in context of an automation spec see the beginning of this header.
+ */
+#define WE_SPEC_CASES_CODE_END() \
+	} \
+}
+
+#endif

--- a/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecVectorToStringUtils.h
+++ b/Plugins/WeekendUtils/Source/WeekendUtils/Public/AutomationTest/AutomationSpecVectorToStringUtils.h
@@ -1,0 +1,57 @@
+﻿///////////////////////////////////////////////////////////////////////////////////////
+/// Copyright (C) by Benjamin Barz and contributors. See file: CREDITS.md
+///
+/// This file is part of the WeekendUtils UE5 Plugin.
+///
+/// Distributed under the MIT License. See file: LICENSE.md
+///
+///////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#if WITH_AUTOMATION_WORKER
+
+namespace WeekendUtils
+{
+	namespace SpecStringUtils
+	{
+		/**
+		 * Alternative implementation of ToString for FVector2 which doesn't introduce weird sub-categories
+		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
+		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(Vector)), [this](){ ... });
+		 */
+		FORCEINLINE FString ToString(const FVector2f& Vector)
+		{
+			return { "(" +
+				FString::FromInt(StaticCast<int>(Vector.X)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.X) * 10)) + " | " +
+				FString::FromInt(StaticCast<int>(Vector.Y)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Y) * 10)) + ")" };
+		}
+		
+		/**
+		 * Alternative implementation of ToString for FVector2 which doesn't introduce weird sub-categories
+		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
+		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(Vector)), [this](){ ... });
+		 */
+		FORCEINLINE FString ToString(const FVector2d& Vector)
+		{
+			return { "(" +
+				FString::FromInt(StaticCast<int>(Vector.X)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.X) * 10)) + " | " +
+				FString::FromInt(StaticCast<int>(Vector.Y)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Y) * 10)) + ")" };
+		}
+		
+		/**
+		 * Alternative implementation of ToString for FVector2 which doesn't introduce weird sub-categories
+		 * based on '.' characters in the session frontend when used in automation spec Describe parameters.
+		 * e.g. Describe(FString::Printf(TEXT("%s"), *SpecStringUtils::ToString(Vector)), [this](){ ... });
+		 */
+		FORCEINLINE FString ToString(const FVector& Vector)
+		{
+			return { "(" +
+				FString::FromInt(StaticCast<int>(Vector.X)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.X) * 10)) + " | " +
+				FString::FromInt(StaticCast<int>(Vector.Y)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Y) * 10)) + " | " +
+				FString::FromInt(StaticCast<int>(Vector.Z)) + "," + FString::FromInt(StaticCast<int>(FMath::Frac(Vector.Z) * 10)) + ")" };
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
Includes:
- macros to execute a Describe- or It-block multiple times with different equally-typed parameters without much boilerplate
- FVector*::ToString alternatives which use ',' instead of '.' for separating integer from fractional part of floating point components. Dots used in Describe `InDescription` parameters cause the spec system to introduce test sub-categories in the session frontend, thus these workarounds.
- fixed a small typo

### Example Usage
```C++
﻿// Copyright Gregor Sönnichsen. All Rights Reserved.

#if WITH_AUTOMATION_WORKER

#include "AutomationSpecVectorToStringUtils.h"
#include "AutomationSpecParametrizationMacros.h"
#include "HoverboardUtils.h"
#include "AutomationTest/AutomationSpecMacros.h"

#define SPEC_TEST_CATEGORY "HoverboardMover"

namespace HoverboardUtilsTestConstants {
	const FVector2f Zero = FVector2f::ZeroVector;
	const FVector2f NegativePitch0_3 = FVector2f{ -0.3f, 0.f };
	...
}

using namespace WeekendUtils;
using namespace HoverboardUtilsTestConstants;

WE_BEGIN_DEFINE_SPEC(Utils)
WE_END_DEFINE_SPEC(Utils)
{
	Describe("ClampPitchRollChangeIfOvershootImminent", [this]
	{
		// @todo: test cases for various boundary-relative scenarios (both below, one below one zero, one below one above, ..)
		WE_SPEC_CASES_SIGNATURE_8(bool, bool, bool, bool, FVector2f, FVector2f, FVector2f, FVector2f)
			WE_SPEC_CASE_8(false, false, false, false, Zero, Zero, PositivePitchRate0_1, Zero)
			WE_SPEC_CASE_8(false, false, false, false, NegativePitch0_2, NegativePitch0_1, PositivePitchRate0_1, NegativePitch0_1)
			WE_SPEC_CASE_8(false, true, false, true, NegativePitch5, NegativePitch4_8, PositivePitchRate0_2, NegativePitch4_9) // expect clamp upwards
			...
		WE_SPEC_CASES_CODE_BEGIN_8(bShouldClampIfBelowTarget, bShouldClampIfAboveTarget, bExpectDownClamp, bExpectUpClamp, PreviousPitchRoll, PitchRoll, PitchRollChangeRate, Boundary)
		Describe(FString::Printf(TEXT("With bClampIsBelow = %hhd, bClampIsAbove = %hhd"),
				Case.bShouldClampIfBelowTarget,
				Case.bShouldClampIfAboveTarget
			),
			[this, Case]
		{
			Describe(FString::Printf(TEXT("With PreviousPR = %s, PR = %s, PRChangeRate = %s, Boundary = %s"),
					*SpecStringUtils::ToString(Case.PreviousPitchRoll),
					*SpecStringUtils::ToString(Case.PitchRoll),
					*SpecStringUtils::ToString(Case.PitchRollChangeRate),
					*SpecStringUtils::ToString(Case.Boundary)
				),
				[this, Case]
			{
				It(FString::Printf(TEXT("should%s clamp below"), Case.bExpectDownClamp ? TEXT("") : TEXT(" NOT")), [this, Case]
				{
					// arrange
					FVector2f PitchRoll = Case.PitchRoll;
					FVector2f PitchRollChangeRate = Case.PitchRollChangeRate;
					
					// act
					auto [bClampedBelow, bClampedAbove] = FHoverboardUtils::ClampPitchRollChangeIfOvershootImminent(
						Case.PreviousPitchRoll,
						IN OUT PitchRoll,
						IN OUT PitchRollChangeRate,
						Case.Boundary,
						Case.bShouldClampIfBelowTarget,
						Case.bShouldClampIfAboveTarget);
												
					// assert
					TestEqual("ClampResult.bClampedBelow == Case.bExpectDownClamp", bClampedBelow, Case.bExpectDownClamp);
				});
				const bool bExpectValueChange = Case.bExpectDownClamp || Case.bExpectUpClamp;
				It(FString::Printf(TEXT("should%s result in PR/PR Change Rate changed"), bExpectValueChange ? TEXT("") : TEXT(" NOT")), [this, Case, bExpectValueChange]
				{
					// arrange
					FVector2f PitchRoll = Case.PitchRoll;
					FVector2f PitchRollChangeRate = Case.PitchRollChangeRate;
					const FVector2f InitialPitchRoll = Case.PitchRoll;
					const FVector2f InitialPitchRollChangeRate = Case.PitchRollChangeRate;
									
					// act
					FHoverboardUtils::ClampPitchRollChangeIfOvershootImminent(
						Case.PreviousPitchRoll,
						IN OUT PitchRoll,
						IN OUT PitchRollChangeRate,
						Case.Boundary,
						Case.bShouldClampIfBelowTarget,
						Case.bShouldClampIfAboveTarget);

					// assert
					TestEqual("bPitchRollChanged", !InitialPitchRoll.Equals(PitchRoll), bExpectValueChange);
					TestEqual("bPitchRollChangeRateChanged", !InitialPitchRollChangeRate.Equals(PitchRollChangeRate), bExpectValueChange);
				});
			});
		});
		WE_SPEC_CASES_CODE_END()
	});
}

#undef SPEC_TEST_CATEGORY
#endif WITH_AUTOMATION_WORKER
```
<img width="722" height="426" alt="grafik" src="https://github.com/user-attachments/assets/a04e7f3a-df4c-450c-903c-2c2c56c02844" />